### PR TITLE
FIX BREAKING CODE: Convert lists into numpy arrays

### DIFF
--- a/Section #4 - Capstone/simpsons.py
+++ b/Section #4 - Capstone/simpsons.py
@@ -58,7 +58,8 @@ featureSet = caer.normalize(featureSet)
 labels = to_categorical(labels, len(characters))
 
 # Creating train and validation data
-x_train, x_val, y_train, y_val = caer.train_val_split(featureSet, labels, val_ratio=.2)
+split_data = caer.train_val_split(featureSet, labels, val_ratio=.2)
+x_train, x_val, y_train, y_val = (np.array(item) for item in split_data)
 
 # Deleting variables to save memory
 del train


### PR DESCRIPTION
The results from caer.train_val_split() were in the form of lists which was not compatible with the latest requirements of canaro.generators.imageDataGenerator().flow(). The current requirement is to convert them into numpy arrays. The same is done in the python file. Kindly accept the pull request and do the same update in the notebook 