### PR TITLE
Update simpsons.ipynb

### DIFF
--- a/Section #4 - Capstone/simpsons.ipynb
+++ b/Section #4 - Capstone/simpsons.ipynb
@@ -192,8 +192,10 @@
         "id": "pzXXrqbt4S7S"
       },
       "source": [
+        "from sklearn.model_selection import train_test_split\n",
         "# Creating train and validation data\n",
-        "x_train, x_val, y_train, y_val = caer.train_val_split(featureSet, labels, val_ratio=.2)"
+        "split_data = train_test_split(feature_set, labels, test_size=0.2)\n",
+        "x_train, x_val, y_train, y_val = (np.array(item) for item in split_data)"
       ],
       "execution_count": null,
       "outputs": []

--- a/Section #4 - Capstone/simpsons.py
+++ b/Section #4 - Capstone/simpsons.py
@@ -12,6 +12,7 @@ import gc
 import matplotlib.pyplot as plt
 from tensorflow.keras.utils import to_categorical
 from tensorflow.keras.callbacks import LearningRateScheduler
+from sklearn.model_selection import train_test_split
 
 
 IMG_SIZE = (80,80)
@@ -58,8 +59,9 @@ featureSet = caer.normalize(featureSet)
 labels = to_categorical(labels, len(characters))
 
 # Creating train and validation data
-split_data = caer.train_val_split(featureSet, labels, val_ratio=.2)
+split_data = train_test_split(featureSet, labels, val_ratio=.2)
 x_train, x_val, y_train, y_val = (np.array(item) for item in split_data)
+
 
 # Deleting variables to save memory
 del train


### PR DESCRIPTION
1. Update dataset split function to work with `sklearn.model_selection.train_test_split()` instead of now deprecated `caer.train_val_split()`
2. Include the conversion of `X_train` and `y_train` to NumPy array as per pull request #5.

Kindly accept this pull request. Similar change might be required in `simpsons.py`