### PR TITLE
train_val_split() is a deprecated feature in caer 

### DIFF
--- a/Section #4 - Capstone/simpsons.ipynb
+++ b/Section #4 - Capstone/simpsons.ipynb
@@ -189,7 +189,7 @@
       "cell_type": "code",
       "execution_count": null,
       "source": [
-        "from sklearn.model_selection import train_test_split",
+        "from sklearn.model_selection import train_test_split \n",
          "x_train, x_val, y_train, y_val = train_test_split(featureSet, labels, test_size=0.2)"
       ],
       "outputs": [],

--- a/Section #4 - Capstone/simpsons.ipynb
+++ b/Section #4 - Capstone/simpsons.ipynb
@@ -189,7 +189,8 @@
       "cell_type": "code",
       "execution_count": null,
       "source": [
-        "x_train, x_val, y_train, y_val = caer.train_test_split(featureSet, labels, val_ratio=.2)"
+        "from sklearn.model_selection import train_test_split"
+         "x_train, x_val, y_train, y_val = train_test_split(featureSet, labels, test_size=0.2)"
       ],
       "outputs": [],
       "metadata": {

--- a/Section #4 - Capstone/simpsons.ipynb
+++ b/Section #4 - Capstone/simpsons.ipynb
@@ -189,7 +189,7 @@
       "cell_type": "code",
       "execution_count": null,
       "source": [
-        "from sklearn.model_selection import train_test_split"
+        "from sklearn.model_selection import train_test_split",
          "x_train, x_val, y_train, y_val = train_test_split(featureSet, labels, test_size=0.2)"
       ],
       "outputs": [],


### PR DESCRIPTION
 Use sklearn.model_selection.train_test_split()